### PR TITLE
Add Numeric Date formatting option

### DIFF
--- a/aura/sdgDatagridCell/sdgDatagridCellController.js
+++ b/aura/sdgDatagridCell/sdgDatagridCellController.js
@@ -112,7 +112,7 @@
                           {
                             value: datevalue,
                             year: "numeric",
-                            month: "numeric",
+                            month: "2-digit",
                             day: "numeric"
                           }
                         );
@@ -172,7 +172,7 @@
                       value: datetimevalue,
                       timeZone: timezone,
                       year: "numeric",
-                      month: "numeric",
+                      month: "2-digit",
                       day: "numeric",
                       hour: "numeric",
                       minute: "numeric",

--- a/aura/sdgDatagridCell/sdgDatagridCellController.js
+++ b/aura/sdgDatagridCell/sdgDatagridCellController.js
@@ -105,7 +105,19 @@
                           component,
                           helper.formatDurationDateTime(component, datevalue)
                         );
-                      } else {
+                      } 
+                    } else if (fieldstyle === "Numeric Date") {
+                        helper.CreateCmp(
+                          component,
+                          "lightning:formattedDateTime",
+                          {
+                            value: datevalue,
+                            year: "numeric",
+                            month: "numeric",
+                            day: "numeric"
+                          }
+                        );
+                    } else {
                         //Render this date WITHOUT a timezone
                         helper.CreateCmp(
                           component,
@@ -155,6 +167,18 @@
                       component,
                       helper.formatDurationDateTime(component, datetimevalue)
                     );
+                  } else if (fieldstyle === "Numeric Date") {
+                    var timezone = $A.get("$Locale.timezone");
+                    helper.CreateCmp(component, "lightning:formattedDateTime", {
+                      value: datetimevalue,
+                      timeZone: timezone,
+                      year: "numeric",
+                      month: "numeric",
+                      day: "numeric",
+                      hour: "numeric",
+                      minute: "numeric",
+                      second: "numeric"
+                    });
                   } else {
                     var timezone = $A.get("$Locale.timezone");
                     helper.CreateCmp(component, "lightning:formattedDateTime", {

--- a/aura/sdgDatagridCell/sdgDatagridCellController.js
+++ b/aura/sdgDatagridCell/sdgDatagridCellController.js
@@ -105,8 +105,7 @@
                           component,
                           helper.formatDurationDateTime(component, datevalue)
                         );
-                      } 
-                    } else if (fieldstyle === "Numeric Date") {
+                      } else if (fieldstyle === "Numeric Date") {
                         helper.CreateCmp(
                           component,
                           "lightning:formattedDateTime",

--- a/objects/SDG_Field__c.object
+++ b/objects/SDG_Field__c.object
@@ -126,6 +126,11 @@
                     <default>false</default>
                     <label>CTI</label>
                 </value>
+                <value>
+                    <fullName>Numeric Date</fullName>
+                    <default>false</default>
+                    <label>Numeric Date</label>
+                </value>
             </valueSetDefinition>
         </valueSet>
     </fields>


### PR DESCRIPTION
Add option to allow date and datetime be formatted in numeric only to keep the same formatting style as the rest of Salesforce